### PR TITLE
releasetools: resize system partition after flashing

### DIFF
--- a/BoardCommonConfig.mk
+++ b/BoardCommonConfig.mk
@@ -71,6 +71,7 @@ BOARD_FLASH_BLOCK_SIZE := 4096
 # Releasetools
 TARGET_RELEASETOOL_OTA_FROM_TARGET_SCRIPT := ./device/samsung/galaxys2-common/releasetools/galaxys2_ota_from_target_files
 TARGET_RELEASETOOL_IMG_FROM_TARGET_SCRIPT := ./device/samsung/galaxys2-common/releasetools/galaxys2_img_from_target_files
+TARGET_RELEASETOOLS_EXTENSIONS := ./device/samsung/galaxys2-common/releasetools/extensions
 
 # Hardware tunables
 BOARD_HARDWARE_CLASS := hardware/samsung/cmhw

--- a/common.mk
+++ b/common.mk
@@ -130,9 +130,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # Filesystem management tools
 PRODUCT_PACKAGES += \
-    static_busybox \
     make_ext4fs \
-    setup_fs
+    resize2fs_static \
+    setup_fs \
+    static_busybox
 
 # Live Wallpapers
 PRODUCT_PACKAGES += \

--- a/releasetools/extensions/releasetools.py
+++ b/releasetools/extensions/releasetools.py
@@ -1,0 +1,10 @@
+import common
+import struct
+
+def FullOTA_PostValidate(info):
+	# run e2fsck
+	info.script.AppendExtra('run_program("/sbin/e2fsck", "-fy", "/dev/block/mmcblk0p9");');
+	# resize2fs: run and delete
+	info.script.AppendExtra('run_program("/tmp/install/bin/resize2fs_static", "/dev/block/mmcblk0p9");');
+	# run e2fsck
+	info.script.AppendExtra('run_program("/sbin/e2fsck", "-fy", "/dev/block/mmcblk0p9");');


### PR DESCRIPTION
resize2fs.static is placed in install/bin, possible to run without /system mounted.
running it will resize /system to the actual system partition size,
supporting custom pits with block-based OTAs

Change-Id: Id2c82add1f697ae3d7e5a1031f6a6d51a4ee53e0
